### PR TITLE
Add Package-Requires header

### DIFF
--- a/helm-flymake.el
+++ b/helm-flymake.el
@@ -5,6 +5,7 @@
 ;; Author: Akira Tamamori <tamamori5917@gmail.com>
 ;; URL: https://github.com/tam17aki
 ;; Version: 0.1.6
+;; Package-Requires: ((helm "1.0"))
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as


### PR DESCRIPTION
With this fix, the file can be installed using package.el, e.g.
from the convenient packages automatically built by
[MELPA](http://melpa.milkbox.net/).

The fix is according to the [Emacs Lisp Manual](http://www.gnu.org/software/emacs/manual/html_node/elisp/Simple-Packages.html).
