### PR TITLE
Added goto line feature using actions and others

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,39 @@
 helm-flymake
 ============
 
+## Installation:
+Add followings on your .emacs.
+
+```elisp
+(require 'helm-config)
+(require 'helm-flymake)
+```
+
+In order for `helm-flymake` to work, `flymake-mode` must be turned on.
+
+```elisp
+(flymake-mode)
+```
+
+Feel free to turn on flymake only the buffers where you want to use it.
+
+## Commentary:
+
+`helm` interface for `flymake`.
+When `flymake-mode` is `t`, ` M-x helm-flymake` lists warning and error
+messages in *helm flymake* buffer.
+
+`C-u M-x helm-flymake` insert the line number of current cursor position
+into minibuffer.
+
+Within the `helm-flymake` buffer if `helm-execute-persistent-action`
+is executed (by default bound to `C-j`), then point will be moved to the
+line number of the selected warning/error. If you would no longer
+like to be at this place in the buffer, simply hit `C-g` to exit the
+`helm-flymake` mini-buffer and point will be returned to its original
+position.
+
+When `Enter/<return>` is pressed the "default" action is executed
+moving point to the line of the selected warning/error and closing
+the `helm-flymake` mini-buffer.
  

--- a/helm-flymake.el
+++ b/helm-flymake.el
@@ -4,7 +4,7 @@
 
 ;; Author: Akira Tamamori <tamamori5917@gmail.com>
 ;; URL: https://github.com/tam17aki
-;; Version: 0.1.7
+;; Version: 0.1.8
 ;; Package-Requires: ((helm "1.0"))
 
 ;; This program is free software; you can redistribute it and/or
@@ -27,7 +27,15 @@
 ;; messages in *helm flymake* buffer.
 ;; C-u M-x `helm-flymake' insert the line number of current cursor position
 ;; into minibuffer.
-;;
+;; Within the `helm-flymake' buffer if `helm-execute-persistent-action'
+;; is executed (by default bound to C-j), then point will be moved to the
+;; line number of the selected warning/error. If you would no longer
+;; like to be at this place in the buffer, simply hit C-g to exit the
+;; `helm-flymake' mini-buffer and point will be returned to its original
+;; position.
+;; When Enter/<return> is pressed the "default" action is executed
+;; moving point to the line of the selected warning/error and closing
+;; the `helm-flymake' mini-buffer.
 
 ;;; Installation:
 ;;
@@ -38,6 +46,12 @@
 ;;
 
 ;;; History:
+;;
+;; Revision 0.1.8
+;; * Added "goto line" feature
+;; * Sorted warnings and errors by line number such that lowest line is first
+;; * Fixed but that showed "nil" in the warning/errors window when there were
+;;   a different numbers of warnings compared to errors (and vise-versa).
 ;;
 ;; Revision 0.1.7
 ;; * convert prefix of helm-c-* into helm-*.
@@ -77,23 +91,59 @@
         for err = (nth 1 err-info)
         append err))
 
+(defun helm-flymake-get-err-list-sorted ()
+  (sort (helm-flymake-get-err-list)
+        (lambda (lhs-err rhs-err)
+          (let ((lhs-line (flymake-ler-line lhs-err))
+                (rhs-line (flymake-ler-line rhs-err)))
+            (> lhs-line rhs-line)))))
+
 (defun helm-flymake-get-candidate (err-type)
-  (mapcar (lambda (err)
-            (let* ((type (flymake-ler-type err))
-                   (text (flymake-ler-text err))
-                   (line (flymake-ler-line err)))
-              (cond
-               ((and (equal type err-type)
-                     (equal err-type "w"))
-                (format "%4s:%s" line text))
-               ((and (equal type err-type)
-                     (equal err-type "e"))
-                (format "%4s:%s" line text)))))
-          (helm-flymake-get-err-list)))
+  (let ((err-list (helm-flymake-get-err-list-sorted))
+        (candidate-list))
+    (mapcar (lambda (err)
+              (let* ((type (flymake-ler-type err))
+                     (text (flymake-ler-text err))
+                     (line (flymake-ler-line err)))
+                (cond
+                 ((and (equal type err-type)
+                       (equal err-type "w"))
+                  (push (format "%s:%s" line text) candidate-list))
+                 ((and (equal type err-type)
+                       (equal err-type "e"))
+                  (push (format "%s:%s" line text) candidate-list)))))
+            err-list)
+    candidate-list))
 
 (defun helm-flymake-init (err-type)
   (helm-init-candidates-in-buffer
    'local (helm-flymake-get-candidate err-type)))
+
+(defmacro helm-flymake-candidate-macro (candidate &rest body)
+  "Execute the forms with CANDIDATE in BODY."
+  (declare (indent 1))
+  `(progn
+     ;; extract the line number from our candidate string
+     ;; candidate format = 123:warning or error message
+     ;; match 1 = whitespace
+     ;; match 2 = line number
+     ;; match 3 = rest of the line after the :
+     (when (string-match "^\\([[:space:]]*\\)\\([0-9]+\\):\\(.*\\)$" candidate)
+       (let ((lineno (string-to-number (match-string 2 candidate))))
+         ,@body))))
+
+(defun helm-flymake-goto-line (line)
+  (goto-char (point-min))
+  (forward-line (1- line)))
+
+(defsubst helm-flymake-recenter ()
+  (recenter (/ (window-height) 2)))
+
+(defun helm-flymake-action-goto-line (candidate)
+  "Switch to line of CANDIDATE."
+  (helm-flymake-candidate-macro candidate
+    (helm-flymake-goto-line lineno)
+    (helm-flymake-recenter)))
 
 (defvar helm-source-flymake-warning
   '((name . "Flymake Warning")
@@ -101,6 +151,7 @@
     (candidates-in-buffer)
     (candidate-transformer . (lambda (cands) (delete "" cands)))
     (type . line)
+    (action . (("Goto Line" . helm-flymake-action-goto-line)))
     (recenter)))
 
 (defvar helm-source-flymake-error
@@ -109,6 +160,7 @@
     (candidates-in-buffer)
     (candidate-transformer . (lambda (cands) (delete "" cands)))
     (type . line)
+    (action . (("Goto Line" . helm-flymake-action-goto-line)))
     (recenter)))
 
 ;;;###autoload


### PR DESCRIPTION
- Added "goto line" feature
- Sorted warnings and errors by line number such that lowest line is first
- Fixed bug that showed "nil" in the warning/errors window when there were a different numbers of warnings compared to errors (and vise-versa).
- Updated README.md
- Bumped version to 0.1.8

By accepting this pull request you can close issue #2 